### PR TITLE
Change the target file path in an archive file since v1.8.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,13 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     steps:
-    - uses: asdf-vm/actions/plugin-test@v1
+    - name: Test the plugin with v1.7.2
+      uses: asdf-vm/actions/plugin-test@v1
+      with:
+        version: 1.7.2
+        command: cmctl version --client
+    - name: Test the plugin with the latest version
+      uses: asdf-vm/actions/plugin-test@v1
       with:
         command: cmctl version --client
   lint:

--- a/bin/install
+++ b/bin/install
@@ -2,6 +2,10 @@
 
 set -euo pipefail
 
+SCRIPT_ROOT="$(cd "$(dirname "$0")"; pwd)"
+# shellcheck disable=SC1090
+source "${SCRIPT_ROOT}/../lib/utils.sh"
+
 function install_cmctl() {
   # local install_type=$1
   local version=$2
@@ -29,7 +33,14 @@ function install_cmctl() {
 
   local tempdir="${TMPDIR:-"$(mktemp -d)"}"
 
-  curl -sL "$download_url" | tar xz -C "$tempdir" "$file"
+  local target_file="$file"
+  # Since 1.8.0, the location of cmctl in the archive file has been changed.
+  # cmctl -> ./cmctl
+  if is_greater "$version" "1.7.99"; then
+    target_file="./$file"
+  fi
+
+  curl -sL "$download_url" | tar xz -C "$tempdir" "$target_file"
 
   mkdir -p "$bin_install_path"
   mv "${tempdir}/${file}" "$bin_path"

--- a/bin/list-all
+++ b/bin/list-all
@@ -2,14 +2,9 @@
 
 set -euo pipefail
 
-function sort_versions() {
-  sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' |
-    LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
-}
-
-function is_greater() {
-  [[ "$(printf '%s\n' "$1" "$2" | sort_versions | head -n1)" == "$2" ]]
-}
+SCRIPT_ROOT="$(cd "$(dirname "$0")"; pwd)"
+# shellcheck disable=SC1090
+source "${SCRIPT_ROOT}/../lib/utils.sh"
 
 function list_all() {
   for version in $(git ls-remote --tags --refs https://github.com/jetstack/cert-manager.git | grep -o 'refs/tags/.*' | cut -d/ -f3- | sed 's/^v//'); do

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+function sort_versions() {
+  sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' |
+    LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
+}
+
+function is_greater() {
+  [[ "$(printf '%s\n' "$1" "$2" | sort_versions | head -n1)" == "$2" ]]
+}
+# vim: ai ts=2 sw=2 et sts=2 ft=sh


### PR DESCRIPTION
Since cert-manager v1.8.0,  the location of cmctl in the archive file has been changed to `./cmctl` from `cmctl`.