### PR TITLE
cmctl moved to a new repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 cmctl is a CLI tool that can help you to manage cert-manager resources inside your cluster.
 
-- https://github.com/jetstack/cert-manager
+- https://github.com/cert-manager/cmctl
 
 ## Install
 

--- a/bin/install
+++ b/bin/install
@@ -27,7 +27,7 @@ function install_cmctl() {
       ;;
   esac
 
-  local download_url="https://github.com/cert-manager/cmctl/releases/download/v${version}/cmctl-${kernel}-${architecture}.tar.gz"
+  local download_url="https://github.com/cert-manager/cmctl/releases/download/v${version}/cmctl_${kernel}_${architecture}.tar.gz"
 
   echo "Downloading cmctl from ${download_url}"
 

--- a/bin/install
+++ b/bin/install
@@ -27,7 +27,7 @@ function install_cmctl() {
       ;;
   esac
 
-  local download_url="https://github.com/jetstack/cert-manager/releases/download/v${version}/cmctl-${kernel}-${architecture}.tar.gz"
+  local download_url="https://github.com/cert-manager/cmctl/releases/download/v${version}/cmctl-${kernel}-${architecture}.tar.gz"
 
   echo "Downloading cmctl from ${download_url}"
 

--- a/bin/list-all
+++ b/bin/list-all
@@ -7,7 +7,7 @@ SCRIPT_ROOT="$(cd "$(dirname "$0")"; pwd)"
 source "${SCRIPT_ROOT}/../lib/utils.sh"
 
 function list_all() {
-  for version in $(git ls-remote --tags --refs https://github.com/jetstack/cert-manager.git | grep -o 'refs/tags/.*' | cut -d/ -f3- | sed 's/^v//'); do
+  for version in $(git ls-remote --tags --refs https://github.com/cert-manager/cmctl.git | grep -o 'refs/tags/.*' | cut -d/ -f3- | sed 's/^v//'); do
     # cmctl is provided since cert-manager v1.6.0.
     # https://cert-manager.io/docs/release-notes/release-notes-1.6/
     ! is_greater "1.5.99" "$version" && echo "$version"


### PR DESCRIPTION
cmctl has moved to a new repo and updated its naming convention from kebab-case to snake_case.
I have updated this locally on my machine, and i am now able to download and manage cmctl through asdf :)
https://cert-manager.io/docs/reference/cmctl/
![image](https://github.com/user-attachments/assets/3b3589d5-700f-4606-8ea7-5af464ba9b2f)
