### PR TITLE
Fix installation URLs for cmctl <2.0.0

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -27,7 +27,7 @@ function install_cmctl() {
       ;;
   esac
 
-  if [[ "$version" < "2.0.0" ]]; then
+  if [[ "$version" == [01].* ]]; then
     local download_url="https://github.com/cert-manager/cert-manager/releases/download/v${version}/cmctl-${kernel}-${architecture}.tar.gz"
   else
     local download_url="https://github.com/cert-manager/cmctl/releases/download/v${version}/cmctl_${kernel}_${architecture}.tar.gz"

--- a/bin/install
+++ b/bin/install
@@ -27,7 +27,11 @@ function install_cmctl() {
       ;;
   esac
 
-  local download_url="https://github.com/cert-manager/cmctl/releases/download/v${version}/cmctl_${kernel}_${architecture}.tar.gz"
+  if [[ "$version" < "2.0.0" ]]; then
+    local download_url="https://github.com/cert-manager/cert-manager/releases/download/v${version}/cmctl-${kernel}-${architecture}.tar.gz"
+  else
+    local download_url="https://github.com/cert-manager/cmctl/releases/download/v${version}/cmctl_${kernel}_${architecture}.tar.gz"
+  fi
 
   echo "Downloading cmctl from ${download_url}"
 


### PR DESCRIPTION
Howdy! I've got a project that is reliant on `cmctl 1.14.x` and I noticed today that our first PR in several months is failing to build in CI due to the relocation of `cmctl` into its own repo. Seems like the changes from #12 work great for all versions `>=2.0.0`, but the binaries for versions `<2.0.0` are still released with the releases for `cert-manager`, so this URL path doesn't work for anything under version 2.

TLDR: v2 releases are here: https://github.com/cert-manager/cmctl/releases while the older versions are still here: https://github.com/cert-manager/cert-manager/releases